### PR TITLE
work

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -540,12 +540,12 @@ thread_id=8308739904 (start_unique_id='42ee7264770745a6b90b9e5e98082a57') == (en
 
 ### つまり
 
-標準モジュールでは、マルチスレッドではthreding.local、コルーチンではcontextvars.ContextVarを使う。
+標準モジュールでは、マルチスレッドではthreading.local、コルーチンではcontextvars.ContextVarを使う。
 
 ### asgiref.local.Localではどうしているのか
 
 * asgiref.local.Localでは、デフォルトではcontextvars.ContextVarを使って値を設定、取得する
-* オプションでthreding.localを使うようにもできる
+* オプションでthreading.localを使うようにもできる
 * 値の取得、設定のコードで排他制御のコードを入れてスレッドセーフになるように工夫している
 
 ### `local_storage.unique_id = ...`のような実装を可能にする仕組み
@@ -558,7 +558,7 @@ thread_id=8308739904 (start_unique_id='42ee7264770745a6b90b9e5e98082a57') == (en
 
 ### まとめ
 
-* threding.local、contextvars.ContextVarはどちらもローカルストレージとして使えるがそれぞれ弱点がある
+* threading.local、contextvars.ContextVarはどちらもローカルストレージとして使えるがそれぞれ弱点がある
 * 標準モジュールには万能のローカルストレージはない
 * asgiref.local.Localは内部でcontextvars.ContextVarを使い、弱点を補う工夫で万能のローカルストレージを実現している
 

--- a/source/index.md
+++ b/source/index.md
@@ -96,6 +96,8 @@
 
 ### docstringによると
 
+<https://github.com/django/asgiref/blob/e38d3c327c01aa82c0bf2726220700c1097ea6cc/asgiref/local.py#L41>
+
 > Local storage for async tasks.
 
 非同期タスク用のローカルストレージ
@@ -550,7 +552,7 @@ thread_id=8308739904 (start_unique_id='42ee7264770745a6b90b9e5e98082a57') == (en
 
 * contextvars.ContextVarは1個の値しか設定できない
 * asgiref.local.Localでは辞書型と組み合わせてcontextvars.ContextVarを使っている
-    * <https://github.com/django/asgiref/blob/05ae3eee3fae4005ae4cfb0bb22d281725fabade/asgiref/local.py#L12>
+    * <https://github.com/django/asgiref/blob/e38d3c327c01aa82c0bf2726220700c1097ea6cc/asgiref/local.py#L12>
 
 ## 最後に
 

--- a/source/index.md
+++ b/source/index.md
@@ -88,7 +88,7 @@
 >>> def sync_function(): ...
 ```
 
-### 今回のトークの主役は`sync_to_async()`ではなくasgiref.local.LocaL
+### 今回のトークの主役は`sync_to_async()`ではなくasgiref.local.Local
 
 実際にasgiref.local.Localを使って役立った体験が本トークのモチベーションなので、今日はasgiref.local.Localの話をします。
 


### PR DESCRIPTION
- **📝 (index.md): fix typo in the name of the module asgiref.local.Local to improve accuracy and readability**
- **📝 (index.md): Update link to correct URL for contextvars.ContextVar usage in asgiref.local.Local**
- **📝 (index.md): fix typos in the text by correcting 'threding' to 'threading' for consistency and clarity in the documentation.**
